### PR TITLE
Feat/append version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,29 @@ Should only be enabled in projects containing the Revit manifest file (`.addin`)
 
 `Clean solution` or `Clean project` commands will delete the deployed files.
 
+#### Versioned folder for local deployment
+
+By default, local deployment copies the add-in into a folder named after the assembly under
+`%AppData%\Autodesk\Revit\Addins\$(RevitVersion)` (for example, `RevitAddIn`).
+
+If you want the deployment folder name to include the assembly version (for example, `RevitAddIn_1.2.3`),
+enable the `AppendVersion` property. Optionally, you can also define a separator between the name and version
+with `VersionDelimiter`:
+
+```xml
+<PropertyGroup>
+    <DeployRevitAddin>true</DeployRevitAddin>
+    <AppendVersion>true</AppendVersion>
+    <VersionDelimiter>_</VersionDelimiter>
+</PropertyGroup>
+```
+
+When `AppendVersion` is enabled and `AssemblyVersion` is defined, the add-in will be deployed into a
+versioned folder, and the `.addin` manifest will be updated automatically to point to the versioned path.
+If `AppendVersion` is not set (or `AssemblyVersion` is missing), the non-versioned folder name is used as before.
+
+_Default: Disabled_
+
 #### Publishing for distribution
 
 If your goal is to generate an installer or a bundle, enable the `PublishRevitAddin` property.

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -16,9 +16,10 @@
         <PublishRevitAddin Condition="'$(PublishRevitAddin)' == ''">false</PublishRevitAddin>
 
 		<AppendVersion Condition="'$(AppendVersion)'!='true' OR '$(AssemblyVersion)'==''">false</AppendVersion>
-		<AddinFolder Condition="'$(AppendVersion)'=='true'">$(AssemblyName)$(VersionDelimiter)$(AssemblyVersion)</AddinFolder>
-		<AddinFolder Condition="'$(AddinFolder)'==''">$(AssemblyName)</AddinFolder>
-		<AddinDeployDir>$(AppDataDeployDir)\$(AddinFolder)</AddinDeployDir>
+		<AddinDeployFolder Condition="'$(AppendVersion)'=='true'">$(AssemblyName)$(VersionDelimiter)$(AssemblyVersion)</AddinDeployFolder>
+		<AddinDeployFolder Condition="'$(AddinDeployFolder)'==''">$(AssemblyName)</AddinDeployFolder>
+		<AddinDeployDir>$(AppDataDeployDir)\$(AddinDeployFolder)</AddinDeployDir>
+		<AddinManifestFileName>$(AssemblyName).addin</AddinManifestFileName>
 	</PropertyGroup>
 
     <Target Name="PublishRevitAddinFiles"
@@ -26,13 +27,13 @@
             Condition="'$(PublishRevitAddin)' == 'true' AND '$(RevitVersion)' != ''">
 
         <ItemGroup>
-            <RootItem Include="$(ProjectDir)*.addin"/>
+            <RootItem Include="$(ProjectDir)**\*$(AddinManifestFileName)"/>
             <AddinItem Include="$(TargetDir)**\*" Exclude="**\$(PublishDirName)\**\*"/>
             <_ResolvedFileToPublishAlways Include="@(Content)" PublishDirectory="%(Content.PublishDirectory)" Condition="'%(Content.CopyToPublishDirectory)' == 'Always'"/>
             <_ResolvedFileToPublishPreserveNewest Include="@(Content)" PublishDirectory="%(Content.PublishDirectory)" Condition="'%(Content.CopyToPublishDirectory)' == 'PreserveNewest'"/>
         </ItemGroup>
 
-        <PropertyGroup>
+		<PropertyGroup>
             <RootDir>$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\</RootDir>
             <AddinDir>$(RootDir)$(AssemblyName)\</AddinDir>
         </PropertyGroup>
@@ -56,7 +57,7 @@
             Condition="'$(DeployRevitAddin)' == 'true'">
 
 		<ItemGroup>
-			<AddinManifest Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\*.addin" />
+			<AddinManifest Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\$(AddinManifestFileName)" />
 			<AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\$(AssemblyName)\**\*" />
 		</ItemGroup>
 
@@ -74,20 +75,20 @@
 		Condition="'$(AppendVersion)' == 'true'">
 
 		<Exec Command="powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass -Command ^
-				 $path='$(AppDataDeployDir)\$(AssemblyName).addin'; ^
+				 $path='$(AppDataDeployDir)\$(AddinManifestFileName)'; ^
 				 $xml=[xml](Get-Content $path); ^
-				 $xml.RevitAddIns.AddIn.Assembly='$(AddinFolder)\$(AssemblyName).dll'; ^
+				 $xml.RevitAddIns.AddIn.Assembly='$(AddinDeployFolder)\$(AssemblyName).dll'; ^
 				 $xml.Save($path)" />
 
-		<Message Text="'$(AssemblyName)\$(AssemblyName).dll' -> '$(AddinFolder)\$(AssemblyName).dll'" Importance="high" />
+		<Message Text="'$(AssemblyName)\$(AssemblyName).dll' -> '$(AddinDeployFolder)\$(AssemblyName).dll'" Importance="high" />
 	</Target>
 
-    <Target Name="CleanRevitAddinFolder"
+    <Target Name="CleanRevitAddinDeployFolder"
             AfterTargets="Clean"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
         <RemoveDir Directories="$(AddinDeployDir)"/>
-        <Delete Files="$(AppDataDeployDir)\$(AssemblyName).addin"/>
+        <Delete Files="$(AppDataDeployDir)\$(AddinManifestFileName)"/>
     </Target>
 
     <Target Name="CleanPublishFolder"

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -12,7 +12,9 @@
         <DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
         <PublishRevitAddin Condition="'$(DeployRevitAddin)' == 'true'">true</PublishRevitAddin>
         <PublishRevitAddin Condition="'$(PublishRevitAddin)' == ''">false</PublishRevitAddin>
-    </PropertyGroup>
+
+		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
+	</PropertyGroup>
 
     <Target Name="PublishRevitAddinFiles"
             AfterTargets="CoreBuild"
@@ -53,17 +55,17 @@
         </ItemGroup>
 
         <Copy SourceFiles="@(AddinFiles)"
-              DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\%(RecursiveDir)"/>
+              DestinationFolder="$(AppDataDeployDir)\%(RecursiveDir)"/>
 
-        <Message Text="$(AssemblyName) -> $(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\" Importance="high"/>
+        <Message Text="$(AssemblyName) -> $(AppDataDeployDir)\" Importance="high"/>
     </Target>
 
     <Target Name="CleanRevitAddinFolder"
             AfterTargets="Clean"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
-        <RemoveDir Directories="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName)"/>
-        <Delete Files="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName).addin"/>
+        <RemoveDir Directories="$(AppDataDeployDir)\$(AssemblyName)"/>
+        <Delete Files="$(AppDataDeployDir)\$(AssemblyName).addin"/>
     </Target>
 
     <Target Name="CleanPublishFolder"

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -16,7 +16,7 @@
 
     <Target Name="PublishRevitAddinFiles"
             AfterTargets="CoreBuild"
-            Condition="$(PublishRevitAddin) == 'true' AND $(RevitVersion) != ''">
+            Condition="'$(PublishRevitAddin)' == 'true' AND '$(RevitVersion)' != ''">
 
         <ItemGroup>
             <RootItem Include="$(ProjectDir)*.addin"/>
@@ -46,7 +46,7 @@
 
     <Target Name="DeployRevitAddinFiles"
             AfterTargets="PublishRevitAddinFiles"
-            Condition="$(DeployRevitAddin)">
+            Condition="'$(DeployRevitAddin)' == 'true'">
 
         <ItemGroup>
             <AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\**\*"/>
@@ -60,7 +60,7 @@
 
     <Target Name="CleanRevitAddinFolder"
             AfterTargets="Clean"
-            Condition="$(DeployRevitAddin)">
+            Condition="'$(DeployRevitAddin)' == 'true'">
 
         <RemoveDir Directories="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName)"/>
         <Delete Files="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName).addin"/>
@@ -68,7 +68,7 @@
 
     <Target Name="CleanPublishFolder"
             AfterTargets="Clean"
-            Condition="$(PublishRevitAddin) == 'true'">
+            Condition="'$(PublishRevitAddin)' == 'true'">
 
         <RemoveDir Directories="$(PublishDir)"/>
     </Target>

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -9,11 +9,16 @@
     -->
 
     <PropertyGroup>
-        <DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
+		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
+
+		<DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
         <PublishRevitAddin Condition="'$(DeployRevitAddin)' == 'true'">true</PublishRevitAddin>
         <PublishRevitAddin Condition="'$(PublishRevitAddin)' == ''">false</PublishRevitAddin>
 
-		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
+		<AppendVersion Condition="'$(AppendVersion)'!='true' OR '$(AssemblyVersion)'==''">false</AppendVersion>
+		<AddinFolder Condition="'$(AppendVersion)'=='true'">$(AssemblyName)$(VersionDelimiter)$(AssemblyVersion)</AddinFolder>
+		<AddinFolder Condition="'$(AddinFolder)'==''">$(AssemblyName)</AddinFolder>
+		<AddinDeployDir>$(AppDataDeployDir)\$(AddinFolder)</AddinDeployDir>
 	</PropertyGroup>
 
     <Target Name="PublishRevitAddinFiles"
@@ -50,21 +55,38 @@
             AfterTargets="PublishRevitAddinFiles"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
-        <ItemGroup>
-            <AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\**\*"/>
-        </ItemGroup>
+		<ItemGroup>
+			<AddinManifest Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\*.addin" />
+			<AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\$(AssemblyName)\**\*" />
+		</ItemGroup>
 
-        <Copy SourceFiles="@(AddinFiles)"
-              DestinationFolder="$(AppDataDeployDir)\%(RecursiveDir)"/>
+		<Copy SourceFiles="@(AddinManifest)"
+			  DestinationFolder="$(AppDataDeployDir)" />
+
+		<Copy SourceFiles="@(AddinFiles)"
+			  DestinationFolder="$(AddinDeployDir)\%(RecursiveDir)" />
 
         <Message Text="$(AssemblyName) -> $(AppDataDeployDir)\" Importance="high"/>
     </Target>
+
+	<Target Name="UpdateAddinManifestPath"
+		AfterTargets="DeployRevitAddinFiles"
+		Condition="'$(AppendVersion)' == 'true'">
+
+		<Exec Command="powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass -Command ^
+				 $path='$(AppDataDeployDir)\$(AssemblyName).addin'; ^
+				 $xml=[xml](Get-Content $path); ^
+				 $xml.RevitAddIns.AddIn.Assembly='$(AddinFolder)\$(AssemblyName).dll'; ^
+				 $xml.Save($path)" />
+
+		<Message Text="'$(AssemblyName)\$(AssemblyName).dll' -> '$(AddinFolder)\$(AssemblyName).dll'" Importance="high" />
+	</Target>
 
     <Target Name="CleanRevitAddinFolder"
             AfterTargets="Clean"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
-        <RemoveDir Directories="$(AppDataDeployDir)\$(AssemblyName)"/>
+        <RemoveDir Directories="$(AddinDeployDir)"/>
         <Delete Files="$(AppDataDeployDir)\$(AssemblyName).addin"/>
     </Target>
 


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
Add support for deploying the Revit add-in into a versioned folder by appending the assembly version to the deployment directory name.

**Description:** 
This change introduces the AppendVersion and VersionDelimiter properties to the MSBuild targets. When enabled (and when AssemblyVersion is available), local deployment publishes the add-in into a versioned subfolder (e.g. MyAddin_1.2.3) and automatically updates the .addin manifest so the Assembly path points to the versioned folder. When AppendVersion is disabled or no version is available, the existing non-versioned behavior is preserved.
Additionally, some MSBuild property conditional 'boolean' comparisons were updated to consistently use quoted string comparisons ('e.g.' =='true') where they were previously missing, for safety.

## Quality Checklist

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] My changes generate no new warnings
