### PR TITLE
Feat/deploy dir

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ Depending on your workflow, you can either deploy the files locally for immediat
 
 #### Local deployment
 
-To copy Revit add-in files to the `%AppData%\Autodesk\Revit\Addins` folder after building a project, you can enable the `DeployRevitAddin` property.
+To copy Revit add-in files to the default `%AppData%\Autodesk\Revit\Addins` folder after building a project, you can enable the `DeployRevitAddin` property.
 
 Copying files helps attach the debugger to the add-in when Revit starts. This makes it easier to test the application or can be used for local development.
 
@@ -103,6 +103,24 @@ _Default: Disabled_
 Should only be enabled in projects containing the Revit manifest file (`.addin`).
 
 `Clean solution` or `Clean project` commands will delete the deployed files.
+
+#### Local deployment location (ProgramData vs AppData)
+
+By default, local deployment copies the add-in files to `%AppData%\Autodesk\Revit\Addins\$(RevitVersion)`.
+
+If you prefer to deploy to `%ProgramData%\Autodesk\Revit\Addins\$(RevitVersion)`, enable the
+`DeployToProgramData` property alongside `DeployRevitAddin`:
+
+```xml
+<PropertyGroup>
+    <DeployRevitAddin>true</DeployRevitAddin>
+    <DeployToProgramData>true</DeployToProgramData>
+</PropertyGroup>
+```
+
+When `DeployToProgramData` is `false` or not set, the add-in continues to be deployed under `%AppData%`.
+
+_Default: Disabled_
 
 #### Versioned folder for local deployment
 

--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,29 @@ Should only be enabled in projects containing the Revit manifest file (`.addin`)
 
 `Clean solution` or `Clean project` commands will delete the deployed files.
 
+#### Versioned folder for local deployment
+
+By default, local deployment copies the add-in into a folder named after the assembly under
+`%AppData%\Autodesk\Revit\Addins\$(RevitVersion)` (for example, `RevitAddIn`).
+
+If you want the deployment folder name to include the assembly version (for example, `RevitAddIn_1.2.3`),
+enable the `AppendVersion` property. Optionally, you can also define a separator between the name and version
+with `VersionDelimiter`:
+
+```xml
+<PropertyGroup>
+    <DeployRevitAddin>true</DeployRevitAddin>
+    <AppendVersion>true</AppendVersion>
+    <VersionDelimiter>_</VersionDelimiter>
+</PropertyGroup>
+```
+
+When `AppendVersion` is enabled and `AssemblyVersion` is defined, the add-in will be deployed into a
+versioned folder, and the `.addin` manifest will be updated automatically to point to the versioned path.
+If `AppendVersion` is not set (or `AssemblyVersion` is missing), the non-versioned folder name is used as before.
+
+_Default: Disabled_
+
 #### Publishing for distribution
 
 If your goal is to generate an installer or a bundle, enable the `PublishRevitAddin` property.

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -12,7 +12,9 @@
         <DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
         <PublishRevitAddin Condition="'$(DeployRevitAddin)' == 'true'">true</PublishRevitAddin>
         <PublishRevitAddin Condition="'$(PublishRevitAddin)' == ''">false</PublishRevitAddin>
-    </PropertyGroup>
+
+		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
+	</PropertyGroup>
 
     <Target Name="PublishRevitAddinFiles"
             AfterTargets="CoreBuild"
@@ -53,17 +55,17 @@
         </ItemGroup>
 
         <Copy SourceFiles="@(AddinFiles)"
-              DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\%(RecursiveDir)"/>
+              DestinationFolder="$(AppDataDeployDir)\%(RecursiveDir)"/>
 
-        <Message Text="$(AssemblyName) -> $(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\" Importance="high"/>
+        <Message Text="$(AssemblyName) -> $(AppDataDeployDir)\" Importance="high"/>
     </Target>
 
     <Target Name="CleanRevitAddinFolder"
             AfterTargets="Clean"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
-        <RemoveDir Directories="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName)"/>
-        <Delete Files="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName).addin"/>
+        <RemoveDir Directories="$(AppDataDeployDir)\$(AssemblyName)"/>
+        <Delete Files="$(AppDataDeployDir)\$(AssemblyName).addin"/>
     </Target>
 
     <Target Name="CleanPublishFolder"

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -16,7 +16,7 @@
 
     <Target Name="PublishRevitAddinFiles"
             AfterTargets="CoreBuild"
-            Condition="$(PublishRevitAddin) == 'true' AND $(RevitVersion) != ''">
+            Condition="'$(PublishRevitAddin)' == 'true' AND '$(RevitVersion)' != ''">
 
         <ItemGroup>
             <RootItem Include="$(ProjectDir)*.addin"/>
@@ -46,7 +46,7 @@
 
     <Target Name="DeployRevitAddinFiles"
             AfterTargets="PublishRevitAddinFiles"
-            Condition="$(DeployRevitAddin)">
+            Condition="'$(DeployRevitAddin)' == 'true'">
 
         <ItemGroup>
             <AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\**\*"/>
@@ -60,7 +60,7 @@
 
     <Target Name="CleanRevitAddinFolder"
             AfterTargets="Clean"
-            Condition="$(DeployRevitAddin)">
+            Condition="'$(DeployRevitAddin)' == 'true'">
 
         <RemoveDir Directories="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName)"/>
         <Delete Files="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName).addin"/>
@@ -68,7 +68,7 @@
 
     <Target Name="CleanPublishFolder"
             AfterTargets="Clean"
-            Condition="$(PublishRevitAddin) == 'true'">
+            Condition="'$(PublishRevitAddin)' == 'true'">
 
         <RemoveDir Directories="$(PublishDir)"/>
     </Target>

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -9,11 +9,16 @@
     -->
 
     <PropertyGroup>
-        <DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
+		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
+
+		<DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
         <PublishRevitAddin Condition="'$(DeployRevitAddin)' == 'true'">true</PublishRevitAddin>
         <PublishRevitAddin Condition="'$(PublishRevitAddin)' == ''">false</PublishRevitAddin>
 
-		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
+		<AppendVersion Condition="'$(AppendVersion)'!='true' OR '$(AssemblyVersion)'==''">false</AppendVersion>
+		<AddinFolder Condition="'$(AppendVersion)'=='true'">$(AssemblyName)$(VersionDelimiter)$(AssemblyVersion)</AddinFolder>
+		<AddinFolder Condition="'$(AddinFolder)'==''">$(AssemblyName)</AddinFolder>
+		<AddinDeployDir>$(AppDataDeployDir)\$(AddinFolder)</AddinDeployDir>
 	</PropertyGroup>
 
     <Target Name="PublishRevitAddinFiles"
@@ -50,21 +55,38 @@
             AfterTargets="PublishRevitAddinFiles"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
-        <ItemGroup>
-            <AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\**\*"/>
-        </ItemGroup>
+		<ItemGroup>
+			<AddinManifest Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\*.addin" />
+			<AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\$(AssemblyName)\**\*" />
+		</ItemGroup>
 
-        <Copy SourceFiles="@(AddinFiles)"
-              DestinationFolder="$(AppDataDeployDir)\%(RecursiveDir)"/>
+		<Copy SourceFiles="@(AddinManifest)"
+			  DestinationFolder="$(AppDataDeployDir)" />
+
+		<Copy SourceFiles="@(AddinFiles)"
+			  DestinationFolder="$(AddinDeployDir)\%(RecursiveDir)" />
 
         <Message Text="$(AssemblyName) -> $(AppDataDeployDir)\" Importance="high"/>
     </Target>
+
+	<Target Name="UpdateAddinManifestPath"
+		AfterTargets="DeployRevitAddinFiles"
+		Condition="'$(AppendVersion)' == 'true'">
+
+		<Exec Command="powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass -Command ^
+				 $path='$(AppDataDeployDir)\$(AssemblyName).addin'; ^
+				 $xml=[xml](Get-Content $path); ^
+				 $xml.RevitAddIns.AddIn.Assembly='$(AddinFolder)\$(AssemblyName).dll'; ^
+				 $xml.Save($path)" />
+
+		<Message Text="'$(AssemblyName)\$(AssemblyName).dll' -> '$(AddinFolder)\$(AssemblyName).dll'" Importance="high" />
+	</Target>
 
     <Target Name="CleanRevitAddinFolder"
             AfterTargets="Clean"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
-        <RemoveDir Directories="$(AppDataDeployDir)\$(AssemblyName)"/>
+        <RemoveDir Directories="$(AddinDeployDir)"/>
         <Delete Files="$(AppDataDeployDir)\$(AssemblyName).addin"/>
     </Target>
 

--- a/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
+++ b/source/Nice3point.Revit.Build.Tasks/targets/Nice3point.Revit.Publish.targets
@@ -10,15 +10,20 @@
 
     <PropertyGroup>
 		<AppDataDeployDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)</AppDataDeployDir>
-
+		<ProgramDataDeployDir>$(ProgramData)\Autodesk\Revit\Addins\$(RevitVersion)</ProgramDataDeployDir>
+		<DeployToProgramData Condition="'$(DeployToProgramData)'==''">false</DeployToProgramData>
+		<DeployDir Condition="'$(DeployToProgramData)'=='true'">$(ProgramDataDeployDir)</DeployDir>
+		<DeployDir Condition="'$(DeployDir)'==''">$(AppDataDeployDir)</DeployDir>
+		
 		<DeployRevitAddin Condition="'$(DeployRevitAddin)' == ''">false</DeployRevitAddin>
         <PublishRevitAddin Condition="'$(DeployRevitAddin)' == 'true'">true</PublishRevitAddin>
         <PublishRevitAddin Condition="'$(PublishRevitAddin)' == ''">false</PublishRevitAddin>
-
-		<AppendVersion Condition="'$(AppendVersion)'!='true' OR '$(AssemblyVersion)'==''">false</AppendVersion>
-		<AddinFolder Condition="'$(AppendVersion)'=='true'">$(AssemblyName)$(VersionDelimiter)$(AssemblyVersion)</AddinFolder>
-		<AddinFolder Condition="'$(AddinFolder)'==''">$(AssemblyName)</AddinFolder>
-		<AddinDeployDir>$(AppDataDeployDir)\$(AddinFolder)</AddinDeployDir>
+		
+		<AppendVersion Condition="'$(AppendVersion)'!='true' OR '$(AssemblyVersion)'==''">false</AppendVersion>	
+		<AddinDeployFolder Condition="'$(AppendVersion)'=='true'">$(AssemblyName)$(VersionDelimiter)$(AssemblyVersion)</AddinDeployFolder>
+		<AddinDeployFolder Condition="'$(AddinDeployFolder)'==''">$(AssemblyName)</AddinDeployFolder>
+		<AddinDeployDir>$(DeployDir)\$(AddinDeployFolder)</AddinDeployDir>
+		<AddinManifestFileName>$(AssemblyName).addin</AddinManifestFileName>
 	</PropertyGroup>
 
     <Target Name="PublishRevitAddinFiles"
@@ -26,13 +31,13 @@
             Condition="'$(PublishRevitAddin)' == 'true' AND '$(RevitVersion)' != ''">
 
         <ItemGroup>
-            <RootItem Include="$(ProjectDir)*.addin"/>
+			<RootItem Include="$(ProjectDir)$(AddinManifestFileName)"/>
             <AddinItem Include="$(TargetDir)**\*" Exclude="**\$(PublishDirName)\**\*"/>
             <_ResolvedFileToPublishAlways Include="@(Content)" PublishDirectory="%(Content.PublishDirectory)" Condition="'%(Content.CopyToPublishDirectory)' == 'Always'"/>
             <_ResolvedFileToPublishPreserveNewest Include="@(Content)" PublishDirectory="%(Content.PublishDirectory)" Condition="'%(Content.CopyToPublishDirectory)' == 'PreserveNewest'"/>
         </ItemGroup>
 
-        <PropertyGroup>
+		<PropertyGroup>
             <RootDir>$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\</RootDir>
             <AddinDir>$(RootDir)$(AssemblyName)\</AddinDir>
         </PropertyGroup>
@@ -56,17 +61,17 @@
             Condition="'$(DeployRevitAddin)' == 'true'">
 
 		<ItemGroup>
-			<AddinManifest Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\*.addin" />
+			<AddinManifest Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\$(AddinManifestFileName)" />
 			<AddinFiles Include="$(PublishDir)\Revit $(RevitVersion) $(Configuration) addin\$(AssemblyName)\**\*" />
 		</ItemGroup>
 
 		<Copy SourceFiles="@(AddinManifest)"
-			  DestinationFolder="$(AppDataDeployDir)" />
+			  DestinationFolder="$(DeployDir)" />
 
 		<Copy SourceFiles="@(AddinFiles)"
 			  DestinationFolder="$(AddinDeployDir)\%(RecursiveDir)" />
 
-        <Message Text="$(AssemblyName) -> $(AppDataDeployDir)\" Importance="high"/>
+        <Message Text="$(AssemblyName) -> $(DeployDir)\" Importance="high"/>
     </Target>
 
 	<Target Name="UpdateAddinManifestPath"
@@ -74,20 +79,20 @@
 		Condition="'$(AppendVersion)' == 'true'">
 
 		<Exec Command="powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass -Command ^
-				 $path='$(AppDataDeployDir)\$(AssemblyName).addin'; ^
+				 $path='$(DeployDir)\$(AddinManifestFileName)'; ^
 				 $xml=[xml](Get-Content $path); ^
-				 $xml.RevitAddIns.AddIn.Assembly='$(AddinFolder)\$(AssemblyName).dll'; ^
+				 $xml.RevitAddIns.AddIn.Assembly='$(AddinDeployFolder)\$(AssemblyName).dll'; ^
 				 $xml.Save($path)" />
 
-		<Message Text="'$(AssemblyName)\$(AssemblyName).dll' -> '$(AddinFolder)\$(AssemblyName).dll'" Importance="high" />
+		<Message Text="'$(AssemblyName)\$(AssemblyName).dll' -> '$(AddinDeployFolder)\$(AssemblyName).dll'" Importance="high" />
 	</Target>
 
-    <Target Name="CleanRevitAddinFolder"
+    <Target Name="CleanRevitAddinDeployFolder"
             AfterTargets="Clean"
             Condition="'$(DeployRevitAddin)' == 'true'">
 
         <RemoveDir Directories="$(AddinDeployDir)"/>
-        <Delete Files="$(AppDataDeployDir)\$(AssemblyName).addin"/>
+        <Delete Files="$(DeployDir)\$(AddinManifestFileName)"/>
     </Target>
 
     <Target Name="CleanPublishFolder"


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
Add an option to deploy the Revit add-in to %ProgramData% instead of %AppData% during local deployment.

**Description:** 
This change introduces a new DeployToProgramData MSBuild property and a shared DeployDir abstraction used by all deploy/update/clean targets. When DeployToProgramData is set to true, the add-in is deployed under %ProgramData%\Autodesk\Revit\Addins\$(RevitVersion); otherwise, it continues to use the existing %AppData%\Autodesk\Revit\Addins\$(RevitVersion) location.

## Quality Checklist

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] My changes generate no new warnings
